### PR TITLE
Update build.go

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -284,9 +284,16 @@ func build(storageDir string, hostname string, options buildOptions) (ret buildR
 		fmt.Fprintf(buf, `
 			try {
 				const %s = require("%s");
-				meta["%s"] = {exports: isObject(%s) ? Object.keys(%s) : ['default'] };
+				if (isObject(%s)) {
+					// remove some keywords which running error in strict mode
+					const keys = Object.keys(%s).filter(d => !["arguments"].includes(d));
+					meta["%s"] = {exports: keys };
+				} else {
+					meta["%s"] = {exports: ['default'] };
+				}
+
 			} catch(e) {}
-		`, importIdentifier, importPath, importPath, importIdentifier, importIdentifier)
+		`, importIdentifier, importPath, importIdentifier, importIdentifier, importPath, importPath)
 	}
 	buf.WriteString(`
 		fs.writeFileSync('./peer.output.json', JSON.stringify(meta))


### PR DESCRIPTION
fix https://github.com/postui/esm.sh/issues/28

when name export include some keyworks like "arguments" will running error in strict mode

such as: 
https://github.com/enricomarino/is ---> https://esm.sh/is

It will be compiled as follows
```
const { arguments } = is;
```
but it will running error in strict mode

![image](https://user-images.githubusercontent.com/7393641/111167300-ee766280-85db-11eb-95f6-dddeb5441a4e.png)


