### PR TITLE
allow reading X-TypeScript-Types reponse header in browser

### DIFF
--- a/server/query.go
+++ b/server/query.go
@@ -445,6 +445,7 @@ func query() rex.Handle {
 				),
 			)
 			ctx.SetHeader("X-TypeScript-Types", value)
+			ctx.SetHeader("Access-Control-Expose-Headers", "X-TypeScript-Types")
 		}
 		ctx.SetHeader("Cache-Control", fmt.Sprintf("private, max-age=%d", refreshDuration))
 		ctx.SetHeader("Content-Type", "application/javascript; charset=utf-8")


### PR DESCRIPTION
Custom headers in browser cross origin requests are omitted unless explicitly whitelisted by the response header 'Access-Control-Expose-Headers'

after this change browser fetch response.headers should contain the X-TypeScript-Types response header and its value