### PR TITLE
docs(README): update link to deno.land x-typescript-types-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ console.log(css)
 
 ### X-Typescript-Types
 
-By default, **esm.sh** will respond with a custom `X-TypeScript-Types` HTTP header when types (`.d.ts`) are defined. This is useful for deno type checks ([link](https://deno.land/manual/getting_started/typescript#x-typescript-types-custom-header)).
+By default, **esm.sh** will respond with a custom `X-TypeScript-Types` HTTP header when types (`.d.ts`) are defined. This is useful for deno type checks ([link](https://deno.land/manual/typescript/types#using-x-typescript-types-header)).
 
 ![figure #1](./embed/assets/sceenshot-deno-types.png)
 


### PR DESCRIPTION
Moved since https://github.com/denoland/deno/commit/02c6a88d8af08d3e3ae79724d9fb12d4a0f8222f