### PR TITLE
Fix setImmediate polyfill args

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -416,7 +416,7 @@ esbuild:
 				fmt.Fprintf(jsHeader, `var __global$ = window;%s`, eol)
 			}
 			if bytes.Contains(outputContent, []byte("__setImmediate$")) {
-				fmt.Fprintf(jsHeader, `var __setImmediate$ = (cb, args) => setTimeout(cb, 0, ...args);%s`, eol)
+				fmt.Fprintf(jsHeader, `var __setImmediate$ = (cb, ...args) => setTimeout(cb, 0, ...args);%s`, eol)
 			}
 			if bytes.Contains(outputContent, []byte("__rResolve$")) {
 				fmt.Fprintf(jsHeader, `var __rResolve$ = p => p;%s`, eol)


### PR DESCRIPTION
This fixes the `setImmediate` polyfill to accept rest-style args instead of an array to match [Node.js](https://nodejs.org/docs/latest-v16.x/api/timers.html#timers_setimmediate_callback_args).
```ts
// Actual node.js type signature
type setImmediate = <Args extends any[]>(fn: (...args: Args) => void, ...args: Args);

// Previous esm.sh type signature:
type setImmediate = <Args extends any[]>(fn: (...args: Args) => void, args: Args);
```

The previous behavior would result in `setImmediate` performing differently. If no arguments were passed or the first argument was not iterable, an exception would be thrown. If the first argument was iterable, it'd be passed as a spread result. I created an example npm module and ran it in deno repl as an example:

```js
> const examples = await import("http://esm.sh/esm-sh-set-immediate-test").then(i => i.default);
> examples.withArray()
> foo bar // expected args [["foo", "bar"]], got ["foo", "bar"]
> examples.withArgs();
> f o o // expected args ["foo", "bar"], got ["f", "o", "o"]
> examples.withNone();
// expected args [], got below exception
Uncaught TypeError: args is not iterable (cannot read property undefined)
    at __setImmediate$ (https://cdn.esm.sh/v41/esm-sh-set-immediate-test@1.0.0/deno/esm-sh-set-immediate-test.js:2:37)
    at Object.withNone (https://cdn.esm.sh/v41/esm-sh-set-immediate-test@1.0.0/deno/esm-sh-set-immediate-test.js:2:833)
    at <anonymous>:2:10
```